### PR TITLE
Docs: Update import examples to remove '/config'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ By default, `nuxt-prepare` will look for a `server.prepare.ts` file in your proj
 
 ```ts
 // `server.prepare.ts`
-import { defineNuxtPrepareHandler } from 'nuxt-prepare/config'
+import { defineNuxtPrepareHandler } from 'nuxt-prepare'
 
 export default defineNuxtPrepareHandler(async () => {
   // Do some async magic here, e.g. fetch data from an API

--- a/docs/api/define-nuxt-prepare-handler.md
+++ b/docs/api/define-nuxt-prepare-handler.md
@@ -36,7 +36,7 @@ function defineNuxtPrepareHandler<T extends ServerInitResult>(
 ## Example
 
 ```ts
-import { defineNuxtPrepareHandler } from 'nuxt-prepare/config'
+import { defineNuxtPrepareHandler } from 'nuxt-prepare'
 
 export default defineNuxtPrepareHandler(async () => {
   // Do some async magic here, e.g. fetch data from an API

--- a/docs/guide/example-env-validation.md
+++ b/docs/guide/example-env-validation.md
@@ -7,7 +7,7 @@ Since Nuxt reads the environment variables at build time from the local `.env` f
 ```ts
 // `server.prepare.ts`
 import { z } from 'zod'
-import { defineNuxtPrepareHandler } from 'nuxt-prepare/config'
+import { defineNuxtPrepareHandler } from 'nuxt-prepare'
 
 export default defineNuxtPrepareHandler(() => {
   const schema = z.object({

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ By default, `nuxt-prepare` will look for a `server.prepare.ts` file in your proj
 
 ```ts
 // `server.prepare.ts`
-import { defineNuxtPrepareHandler } from 'nuxt-prepare/config'
+import { defineNuxtPrepareHandler } from 'nuxt-prepare'
 
 export default defineNuxtPrepareHandler(async () => {
   // Do some async magic here, e.g. fetch data from an API


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Closes #1 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changed all instances of `import { defineNuxtPrepareHandler } from 'nuxt-prepare/config'` to `import { defineNuxtPrepareHandler } from 'nuxt-prepare/'`

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
