### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,7 @@
 > [📖 Read the documentation](https://nuxt-prepare.byjohann.dev)
 
 ```bash
-# pnpm
-pnpm add -D nuxt-prepare
-
-# npm
-npm i -D nuxt-prepare
-
-# yarn
-yarn add -D nuxt-prepare
+npx nuxi@latest module add prepare
 ```
 
 ## Basic Usage

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,18 +11,9 @@
 This guide will walk you through the steps to get started with `nuxt-prepare`.
 
 ## Step 1: Install `nuxt-prepare`
-
-::: code-group
-  ```bash [pnpm]
-  pnpm add -D nuxt-prepare
-  ```
-  ```bash [yarn]
-  yarn add -D nuxt-prepare
-  ```
-  ```bash [npm]
-  npm install -D nuxt-prepare
-  ```
-:::
+```bash
+npx nuxi@latest module add prepare
+```
 
 ## Step 2: Use `nuxt-prepare`
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,6 +11,7 @@
 This guide will walk you through the steps to get started with `nuxt-prepare`.
 
 ## Step 1: Install `nuxt-prepare`
+
 ```bash
 npx nuxi@latest module add prepare
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
