### PR TITLE
feat: support running scripts in projects with layers

### DIFF
--- a/playground/layers/nested/layer.prepare.ts
+++ b/playground/layers/nested/layer.prepare.ts
@@ -1,0 +1,9 @@
+import { defineNuxtPrepareHandler } from '../../../src/config'
+
+export default defineNuxtPrepareHandler(() => {
+  console.log('This is a log message from "layer.prepare" script')
+
+  return {
+    ok: true,
+  }
+})

--- a/playground/layers/nested/nuxt.config.ts
+++ b/playground/layers/nested/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  prepare: {
+    scripts: [
+      { file: 'layer.prepare.ts', runOnNuxtPrepare: true },
+    ],
+  },
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,6 +2,8 @@ import { defineNuxtConfig } from 'nuxt/config'
 import NuxtPrepare from '../src/module'
 
 export default defineNuxtConfig({
+  extends: ['./layers/nested'],
+
   modules: [NuxtPrepare],
 
   runtimeConfig: {
@@ -10,7 +12,7 @@ export default defineNuxtConfig({
     },
   },
 
-  compatibilityDate: '2024-04-03',
+  compatibilityDate: '2026-01-01',
 
   prepare: {
     scripts: [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,12 @@ export function toArray<T>(value: T | T[]): T[] {
 export function isObject(value: unknown): value is Record<any, any> {
   return Object.prototype.toString.call(value) === '[object Object]'
 }
+
+export function stripExtension(name: string, extensions: string[]): string {
+  for (const ext of extensions) {
+    if (name.endsWith(ext))
+      return name.slice(0, -ext.length)
+  }
+
+  return name
+}


### PR DESCRIPTION
### 🔗 Linked issue

#21

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR resolves #21 by generating paths for prepare scripts using their relevant layer's root directory. Scripts are run in order by layer, i.e. with the main project's scripts running first.

#### Notes

- To account for the possibility of scripts on different layers having the same name, I revised the script dedupe step to check whether the script's path is unique instead of its name
- I've added a `nested` layer within the playground that includes a prepare script for testing layer support
- As the layers functionality in Nuxt underwent changes throughout v3, adding this support may necessitate bumping up the current minimum supported version of 3.0.0

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
